### PR TITLE
Marcelo

### DIFF
--- a/src/Command/CreateSymlinksCommand.php
+++ b/src/Command/CreateSymlinksCommand.php
@@ -108,6 +108,11 @@ class CreateSymlinksCommand extends Command
         }
         $codeDirectory = $str = rtrim($codeDirectory, '/');
 
+        // Convert the alias for home directory into the real path i.e. ~/dev/drupal-console.
+        if (substr($codeDirectory, 0, 2) == '~/') {
+            $codeDirectory = getenv('HOME') . '/' . substr($codeDirectory, 2, strlen($codeDirectory));
+        }
+
         $io->writeln(
             $this->trans('commands.develop.create.symlinks.messages.symlink')
         );

--- a/src/Command/CreateSymlinksCommand.php
+++ b/src/Command/CreateSymlinksCommand.php
@@ -117,8 +117,7 @@ class CreateSymlinksCommand extends Command
             $this->trans('commands.develop.create.symlinks.messages.symlink')
         );
 
-        $codePackages = $this->populatePackages($codeDirectory);
-        $this->packages = $codePackages;
+        $this->packages = $this->populatePackages($codeDirectory);
         $sitePackages = $this->populatePackages($this->consoleRoot . '/vendor/drupal');
 
         foreach ($this->packages as $name => $package) {


### PR DESCRIPTION
This PR allows the creation of symlinks to work with any folder name
It scans the code directory and finds the drupal packages in the composer.json files

It also allows you to use ~/ instead of /user/name/