### PR TITLE
Add namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,19 @@
             "email": "enzos@weknowinc.com"
         }
     ],
-    "require": {},
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {
         "psr-4": {"Drupal\\Console\\Develop\\": "src"}
     },
+    "extra": {
+        "class": "Drupal\\Console\\Develop\\Composer\\ConsoleDevelopPluginInterface"
+    },
+    "require": {
+        "composer-plugin-api": "^1.0"
+    },
     "require-dev": {
-        "drupal/console-core": "~1.0"
+        "drupal/console-core": "~1.0",
+        "composer/composer": "^1.9"
     }
 }

--- a/src/Command/DevelopDocDataCommand.php
+++ b/src/Command/DevelopDocDataCommand.php
@@ -64,8 +64,27 @@ class DevelopDocDataCommand extends Command
         $data['language'] = $applicationData['default_language'];
         $data['type'] = 'commands';
 
+        $excludeNamespaces = ['misc', 'demo', 'version', 'develop'];
+        $excludeCommands = ['demo', 'version', 'develop'];
+
         foreach ($namespaces as $namespace) {
+            if(!in_array($namespace, $excludeNamespaces)){
+                $data['namespaces'][] = ['name' => $namespace];
+            }
+
+            if(in_array($namespace, $excludeCommands)) {
+                continue;
+            }
+
             foreach ($applicationData['commands'][$namespace] as $command) {
+                if(!empty($command['options'])){
+                    $command['options'] = array_values($command['options']);
+                }
+
+                if(!empty($command['arguments'])){
+                    $command['arguments'] = array_values($command['arguments']);
+                }
+
                 $data['commands'][] = $command;
             }
         }

--- a/src/Composer/ConsoleDevelopInstaller.php
+++ b/src/Composer/ConsoleDevelopInstaller.php
@@ -1,0 +1,81 @@
+<?php
+namespace Drupal\Console\Develop\Composer;
+
+use Composer\Package\PackageInterface;
+use Composer\Repository\InstalledRepositoryInterface;
+use Composer\Installer\LibraryInstaller;
+use InvalidArgumentException;
+
+class ConsoleDevelopInstaller extends LibraryInstaller
+{
+  /**
+   * Decides if the installer supports the given type
+   *
+   * @param string $packageType
+   * @return bool
+   */
+  public function supports($packageType)
+  {
+    return 'drupal-console-library' === $packageType;
+  }
+
+  /**
+   * Checks that provided package is installed.
+   *
+   * @param InstalledRepositoryInterface $repo repository in which to check
+   * @param PackageInterface $package package instance
+   *
+   * @return bool
+   */
+  public function isInstalled(InstalledRepositoryInterface $repo, PackageInterface $package)
+  {
+    // TODO: Implement isInstalled() method.
+  }
+
+  /**
+   * Installs specific package.
+   *
+   * @param InstalledRepositoryInterface $repo repository in which to check
+   * @param PackageInterface $package package instance
+   */
+  public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
+  {
+    // TODO: Implement install() method.
+  }
+
+  /**
+   * Updates specific package.
+   *
+   * @param InstalledRepositoryInterface $repo repository in which to check
+   * @param PackageInterface $initial already installed package version
+   * @param PackageInterface $target updated version
+   *
+   * @throws InvalidArgumentException if $initial package is not installed
+   */
+  public function update(InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $target)
+  {
+    // TODO: Implement update() method.
+  }
+
+  /**
+   * Uninstalls specific package.
+   *
+   * @param InstalledRepositoryInterface $repo repository in which to check
+   * @param PackageInterface $package package instance
+   */
+  public function uninstall(InstalledRepositoryInterface $repo, PackageInterface $package)
+  {
+    // TODO: Implement uninstall() method.
+  }
+
+  /**
+   * Returns the installation path of a package
+   *
+   * @param PackageInterface $package
+   * @return string           path
+   */
+  public function getInstallPath(PackageInterface $package)
+  {
+    return 'vendor/drupal/'.$package->getPrettyName();
+  }
+}

--- a/src/Composer/ConsoleDevelopPluginInterface.php
+++ b/src/Composer/ConsoleDevelopPluginInterface.php
@@ -1,0 +1,21 @@
+<?php
+namespace Drupal\Console\Develop\Composer;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+
+class ConsoleDevelopPluginInterface implements PluginInterface
+{
+  /**
+   * Apply plugin modifications to Composer
+   *
+   * @param Composer $composer
+   * @param IOInterface $io
+   */
+  public function activate(Composer $composer, IOInterface $io)
+  {
+    $installer = new ConsoleDevelopInstaller($io, $composer);
+    $composer->getInstallationManager()->addInstaller($installer);
+  }
+}


### PR DESCRIPTION
This PR tries to create a custom composer installer for `drupal-console-library` type. It installer will install the projects with  `drupal-console-library`type in `vendor/drupal`

For now, It doesn't work because the composer file doesn't execute the ConsoleDevelopPluginInterface file that contains the installer class

Resource:
https://getcomposer.org/doc/articles/custom-installers.md
